### PR TITLE
Update dependencies so running the gatsby portfolio example will work

### DIFF
--- a/shape-portfolio-gatsbyjs/package.json
+++ b/shape-portfolio-gatsbyjs/package.json
@@ -7,13 +7,13 @@
     "email": "contact@takeshape.io"
   },
   "dependencies": {
-    "gatsby": "^2.20.10",
+    "gatsby": "^2.24.2",
     "gatsby-plugin-manifest": "^2.3.3",
     "gatsby-plugin-offline": "^2.0.5",
     "gatsby-plugin-react-helmet": "^3.0.0",
     "gatsby-source-graphql": "^2.0.18",
-    "react": "^16.5.1",
-    "react-dom": "^16.5.1",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "react-helmet": "^5.2.0",
     "slugify": "^1.3.2",
     "takeshape-routing": "^4.53.0"


### PR DESCRIPTION
I ran into this error when trying to run `shape-portfolio-gatsbyjs`:

```
Dark-Egg:shape-portfolio-gatsbyjs gregorysmith$ npm run start

> takeshape-shape-portfolio-gatsbyjs@1.0.0 start /Users/gsmith/Code/takeshape-samples/shape-portfolio-gatsbyjs
> npm run develop


> takeshape-shape-portfolio-gatsbyjs@1.0.0 develop /Users/gsmith/Code/takeshape-samples/shape-portfolio-gatsbyjs
> gatsby develop

The above error occurred in the <StoreStateProvider> component:
    in StoreStateProvider
    in App
```

Based on a suggestions from [this gatsby issue](https://github.com/gatsbyjs/gatsby/issues/19827) I found it worked if I updated the dependencies.