### PR TITLE
remove unstable_ and fix end of getStaticPaths

### DIFF
--- a/shape-blog-nextjs/src/pages/author/[slug].js
+++ b/shape-blog-nextjs/src/pages/author/[slug].js
@@ -87,17 +87,14 @@ export async function getStaticPaths() {
   try {
     const res = await TakeShape.graphql({query: authorSlugsQuery})
     const json = await res.json()
-	console.log(json)
     if (json.errors) throw json.errors
     const data = json.data
     const authors = data.authors.items
 
-	const output = {
+	return {
 		paths: authors.map(author => ({params: {slug: author.slug}})),
 		fallback: false
 	};
-	console.log(output)
-	return output
   } catch (error) {
     console.error(error)
     return error

--- a/shape-blog-nextjs/src/pages/author/[slug].js
+++ b/shape-blog-nextjs/src/pages/author/[slug].js
@@ -65,7 +65,7 @@ const AuthorPage = ({data}) => {
   )
 }
 
-export async function unstable_getStaticProps({ params }) { 
+export async function getStaticProps({ params }) {
   try {
     const {slug} = params
     const res = await TakeShape.graphql({query: authorQuery(slug)})
@@ -83,16 +83,21 @@ export async function unstable_getStaticProps({ params }) {
   }
 }
 
-export async function unstable_getStaticPaths() {
+export async function getStaticPaths() {
   try {
     const res = await TakeShape.graphql({query: authorSlugsQuery})
     const json = await res.json()
+	console.log(json)
     if (json.errors) throw json.errors
     const data = json.data
     const authors = data.authors.items
-    return authors.reduce((pages, author) => pages.concat({
-      params: {slug: author.slug}
-    }), [])
+
+	const output = {
+		paths: authors.map(author => ({params: {slug: author.slug}})),
+		fallback: false
+	};
+	console.log(output)
+	return output
   } catch (error) {
     console.error(error)
     return error

--- a/shape-blog-nextjs/src/pages/index.js
+++ b/shape-blog-nextjs/src/pages/index.js
@@ -93,7 +93,7 @@ export const homePageQuery = `
 	}
 `
 
-export async function unstable_getStaticProps() {
+export async function getStaticProps() {
 	try {
 		const res = await TakeShape.graphql({query: homePageQuery})
 		const json = await res.json()

--- a/shape-blog-nextjs/src/pages/posts/[slug].js
+++ b/shape-blog-nextjs/src/pages/posts/[slug].js
@@ -83,7 +83,7 @@ const PostPage = ({data}) => {
   )
 }
 
-export async function unstable_getStaticProps({ params }) {
+export async function getStaticProps({ params }) {
   try {
     const {slug} = params
     const res = await TakeShape.graphql({query: postQuery(slug)})
@@ -101,16 +101,20 @@ export async function unstable_getStaticProps({ params }) {
   }
 }
 
-export async function unstable_getStaticPaths() {
+export async function getStaticPaths() {
   try {
     const res = await TakeShape.graphql({query: postSlugsQuery})
     const json = await res.json()
     if (json.errors) throw json.errors
     const data = json.data
     const posts = data.posts.items
-    return posts.reduce((pages, post) => pages.concat({
-      params: {slug: post.slug}
-    }), [])
+
+	const output = {
+		paths: posts.map(post => ({params: {slug: post.slug}})),
+		fallback: false
+	};
+	console.log(output)
+	return output
   } catch (error) {
     console.error(error)
     return error

--- a/shape-blog-nextjs/src/pages/posts/[slug].js
+++ b/shape-blog-nextjs/src/pages/posts/[slug].js
@@ -109,12 +109,10 @@ export async function getStaticPaths() {
     const data = json.data
     const posts = data.posts.items
 
-	const output = {
+	return {
 		paths: posts.map(post => ({params: {slug: post.slug}})),
 		fallback: false
 	};
-	console.log(output)
-	return output
   } catch (error) {
     console.error(error)
     return error

--- a/shape-blog-nextjs/src/pages/posts/index.js
+++ b/shape-blog-nextjs/src/pages/posts/index.js
@@ -31,7 +31,7 @@ export const postListQuery = `
 `
 
 const PostListPage = (props) => {
-  const { 
+  const {
     data,
   } = props;
   return (
@@ -48,7 +48,7 @@ const PostListPage = (props) => {
   )
 }
 
-export async function unstable_getStaticProps() {
+export async function getStaticProps() {
   try {
     const res = await TakeShape.graphql({query: postListQuery})
     const json = await res.json()


### PR DESCRIPTION
The problem here essentially is just the when compiling, NextJS is throwing errors about how `unstable_getStaticProps` and `unstable_getStaticPaths` are no longer functions. Once the name of the functions were changed to the more appropriate version (`getStaticProps` snd `getStaticPaths`), the return value of the functions had to be changed to fit the new standard:
```
{
	paths: [
		{params: {slug: "string"}},
		{params: {slug: "string"}},
		{params: {slug: "string"}},
		{params: {slug: "string"}},
		...
	],
	fallback: false
}
```
This was fixed in this PR.

-- edit: I still have to remove debug code I left in by accident. sorry, still getting used to this